### PR TITLE
add support for Huawei domain like in the used library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+This is an integration for Home Assistant that uses the following library :
+
+https://pypi.org/project/fusion-solar-py/, which is used for reading data from the Huawei Fusion Solar cloud, with the common web login ( not API ).
+
+This is especially useful if your PV system installer has not provided you with an API account.
+
+To add this to your Home Assistant (HA) installation, one does the following:
+ - on the HA machine go to the config folder (/config)
+ - check the existence of the custom_components folder - create it if not existing and then copy the fusion_solar folder in there
+ - go to the HA dashboard - Settings - Devices & Services
+ - click on ADD INTEGRATION, search for FusionSolar and a login screen should appear
+ - make sure the subdomain matches the one you see if you login on the fusion solar website - it will not work otherwise
+
+ Once added, the sensors can be seen in the overview screen and used in further automation.

--- a/custom_components/fusion_solar/__init__.py
+++ b/custom_components/fusion_solar/__init__.py
@@ -31,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # TODO: catch connection exceptions
     try:
         fusion_client = await hass.async_add_executor_job(
-            FusionSolarClient, entry.data["username"], entry.data["password"]
+            FusionSolarClient, entry.data["username"], entry.data["password"], entry.data["huawei_subdomain"]
         )
     except AuthenticationException as error:
         raise ConfigEntryAuthFailed from error

--- a/custom_components/fusion_solar/config_flow.py
+++ b/custom_components/fusion_solar/config_flow.py
@@ -21,6 +21,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required("username"): str,
         vol.Required("password"): str,
+        vol.Optional("huawei_subdomain", default="region03eu5"): str
     }
 )
 
@@ -32,14 +33,14 @@ class FusionSolar:
         """Initialize."""
         self.client = None
 
-    async def authenticate(self, username: str, password: str) -> bool:
+    async def authenticate(self, username: str, password: str, huawei_subdomain: str) -> bool:
         """Test if we can authenticate with the host."""
 
         try:
             if self.client:
                 self.client.log_out()
 
-            self.client = FusionSolarClient(username, password)
+            self.client = FusionSolarClient(username, password, huawei_subdomain)
         except AuthenticationException as error:
             _LOGGER.warning(
                 "Wrong username or password for the FusionSolar API: %s", str(error)
@@ -62,7 +63,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     try:
         # only creating the client already attempts a login
         await hass.async_add_executor_job(
-            FusionSolarClient, data["username"], data["password"]
+            FusionSolarClient, data["username"], data["password"], data["huawei_subdomain"]
         )
     except AuthenticationException as error:
         raise InvalidAuth from error

--- a/custom_components/fusion_solar/strings.json
+++ b/custom_components/fusion_solar/strings.json
@@ -5,7 +5,8 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "huawei_subdomain": "[%key:common::config_flow::data::huawei_subdomain%]"
         }
       }
     },

--- a/custom_components/fusion_solar/translations/en.json
+++ b/custom_components/fusion_solar/translations/en.json
@@ -12,7 +12,8 @@
             "user": {
                 "data": {
                     "password": "Password",
-                    "username": "Username"
+                    "username": "Username",
+                    "huawei_subdomain": "Huawei Fusion subdomain"
                 }
             }
         }


### PR DESCRIPTION
This adds support for setting the default domain for Fusion Solar to something else than the default in the library : https://pypi.org/project/fusion-solar-py/ . region03eu5 is default.
Tested in HA OS latest.